### PR TITLE
Add dayof APIs

### DIFF
--- a/registration_2019/core.py
+++ b/registration_2019/core.py
@@ -27,6 +27,7 @@ import registration_2019.email_list
 import registration_2019.authentication
 import registration_2019.registration
 import registration_2019.mentor
+import registration_2019.dayof
 
 # create db tables
 db.create_all()

--- a/registration_2019/dayof.py
+++ b/registration_2019/dayof.py
@@ -1,0 +1,102 @@
+import datetime
+import enum
+from sqlalchemy import Column, String, SmallInteger, Integer, Enum, Boolean, ForeignKey, DateTime
+from flask import redirect
+from flask_restful import Resource, reqparse
+from .core import api, db, app
+from .helper import *
+from .authentication import auth
+from .registration import Signup, SignIn
+
+## Helpers
+
+def validate_badge_data(badge_data):
+    # TODO validate badge_data based on whatever method we decide
+    return True
+
+def sign_in(user_id, badge_data):
+    if not validate_badge_data(badge_data):
+        return {"message": "Invalid badge data"}, 400
+    signup = Signup.query.filter_by(user_id=user_id, outdated=False).scalar()
+    if signup and signup.sign_in:
+        return {"message": "User already signed in"}, 400
+    sign_in = SignIn(badge_data=badge_data)
+    db.session.add(sign_in)
+    # Could use the modify method, but interaction would be non-trivial given that its designed for forward facing API
+    signup.sign_in = sign_in
+    db.session.commit()
+
+    return {"status": "ok"}
+
+def sign_out(badge_data):
+    sign_in = SignIn.query.filter_by(badge_data=badge_data).scalar()
+    if not sign_in:
+        return {"message": "Invalid badge"}, 400
+    if sign_in.signed_out:
+        return {"message": "User already signed out"}, 400
+    sign_in.signed_out = True
+    db.session.commit()
+    return {"status": "ok"}
+
+def meal_line(args):
+    if args["meal_number"] > 9 or args["meal_number"] < 1:
+        return {"message": "Invalid meal number"}, 400
+    sign_in = SignIn.query.filter_by(badge_data=args.get("badge_data")).scalar()
+    if not sign_in:
+        return {"message": "Invalid badge"}, 400
+    meal_name = "meal_" + str(args["meal_number"])
+    times = getattr(sign_in, meal_name)
+    if times >= args["allowed_servings"]:
+        return {"message": "User has already received allowed servings for this meal"}, 400
+    setattr(sign_in, meal_name, times+1)
+    db.session.commit()
+    return {"status": "ok", "message": "Servings received incremented"}
+
+
+## Endpoints
+
+class SignInEndpoint(Resource):
+
+    parser = reqparse.RequestParser()
+
+    def __init__(self):
+
+        self.parser.add_argument('user_id',            type=strn, required=True)
+        self.parser.add_argument('badge_data',         type=strn, required=True)
+
+    @auth
+    def post(self):
+        args = self.parser.parse_args()
+        return sign_in(args['user_id'], args['badge_data'])
+
+    def get(self):
+        return Signup.query.filter(Signup.sign_in_id.isnot(None), Signup.outdated == False).count()
+
+class SignOutEndpoint(Resource):
+
+    parser = reqparse.RequestParser()
+
+    def __init__(self):
+        self.parser.add_argument('badge_data',         type=strn, required=True)
+
+    @auth
+    def post(self):
+        args = self.parser.parse_args()
+        return sign_out(args['badge_data'])
+
+class MealLine(Resource):
+    parser = reqparse.RequestParser()
+
+    def __init__(self):
+        self.parser.add_argument('badge_data',         type=strn, required=True)
+        self.parser.add_argument('meal_number',        type=int,  required=True)
+        self.parser.add_argument('allowed_servings',   type=int,  required=True)
+
+    @auth
+    def post(self):
+        args = self.parser.parse_args()
+        return meal_line(args)
+
+api.add_resource(SignInEndpoint,  '/registration/v1/sign-in')
+api.add_resource(SignOutEndpoint, '/registration/v1/sign-out')
+api.add_resource(MealLine,        '/registration/v1/meal')

--- a/registration_2019/registration.py
+++ b/registration_2019/registration.py
@@ -30,6 +30,21 @@ class EmailVerification(db.Model):
     email_token = Column(String(36),  nullable=False, default=rand_uuid)
     verified    = Column(Boolean,     nullable=False, default=False)
 
+# This has to be in this file to avoid circular dependencies in dayof.py
+# Actual logic related to this data is in dayof.py
+class SignIn(db.Model):
+    id          = Column(Integer,     nullable=False, primary_key=True)
+    badge_data  = Column(String(128),  nullable=False)
+    signed_out  = Column(Boolean, nullable=False, default=False)
+    meal_1      = Column(SmallInteger, nullable=False, default=0)
+    meal_2      = Column(SmallInteger, nullable=False, default=0)
+    meal_3      = Column(SmallInteger, nullable=False, default=0)
+    meal_4      = Column(SmallInteger, nullable=False, default=0)
+    meal_5      = Column(SmallInteger, nullable=False, default=0)
+    meal_7      = Column(SmallInteger, nullable=False, default=0)
+    meal_8      = Column(SmallInteger, nullable=False, default=0)
+    meal_9      = Column(SmallInteger, nullable=False, default=0)
+
 class Signup(db.Model):
     id                    = Column(Integer,                    nullable=False, primary_key=True)
     user_id               = Column(String(36),                 nullable=False, default=rand_uuid)
@@ -52,11 +67,13 @@ class Signup(db.Model):
     dietary_restrictions  = Column(String(255))
     signed_waiver         = Column(Boolean,                    nullable=False, default=False)
     email_verification_id = Column(Integer,                    ForeignKey(EmailVerification.id))
+    sign_in_id             = Column(Integer,                    ForeignKey(SignIn.id), nullable=True)
     acceptance_status     = Column(Enum(AcceptanceStatusEnum), nullable=False, default=AcceptanceStatusEnum.none)
     outdated              = Column(Boolean,                    nullable=False, default=False)
     timestamp             = Column(DateTime,                   nullable=False, default=datetime.datetime.utcnow)
 
     email_verification    = db.relationship('EmailVerification', foreign_keys='Signup.email_verification_id')
+    sign_in                = db.relationship('SignIn', foreign_keys='Signup.sign_in_id')
 
     def as_dict(self):
         result = {c.name: help_jsonify(getattr(self, c.name)) for c in self.__table__.columns}


### PR DESCRIPTION
Without a proper database migration tool, we'll need to add the `sign_in_id` field to the SignUps table manually. It's hence null by default by design.
@nayaverdier 
@JamsheedMistri 

I've done some testing locally already.